### PR TITLE
a fix for windows; add a few more compression xml

### DIFF
--- a/gadgets/CMakeLists.txt
+++ b/gadgets/CMakeLists.txt
@@ -8,6 +8,11 @@ find_package(ACE)
 find_package(FFTW3 COMPONENTS single double)
 find_package(Ismrmrd)
 find_package(ZFP)
+if (ZFP_FOUND)
+    message("ZFP Found")
+else (ZFP_FOUND)
+    message("ZFP NOT Found")
+endif (ZFP_FOUND)
 
 include_directories(
   ${CMAKE_BINARY_DIR}/apps/gadgetron

--- a/gadgets/compression/CMakeLists.txt
+++ b/gadgets/compression/CMakeLists.txt
@@ -14,13 +14,24 @@ include_directories(
     ${ISMRMRD_INCLUDE_DIR}
 )
 
+set( config_files 
+    config/default_compression.xml
+    config/Generic_Cartesian_Grappa_EPI_AVE_Compression.xml
+    config/Generic_Cartesian_Grappa_EPI_Compression.xml
+    config/Generic_Cartesian_Grappa_RealTimeCine_Compression.xml
+    config/Generic_Cartesian_Grappa_SNR_Compression.xml
+    config/Generic_Cartesian_NonLinear_Spirit_RealTimeCine_Compression_Cloud.xml
+    config/ismrmrd_dump_compressed.xml 
+)
+
 add_library(gadgetron_compression SHARED 
     gadgetron_compression_gadgets_export.h 
     GadgetIsmrmrdCompressedReadWrite.h
     GadgetIsmrmrdCompressedReadWrite.cpp
+    ${config_files} 
 )
 
-set_target_properties(gadgetron_compression PROPERTIES VERSION ${GADGETRON_VERSION_STRING} SOVERSION ${GADGETRON_SOVERSION})                                                                                                                                                                                                      
+set_target_properties(gadgetron_compression PROPERTIES VERSION ${GADGETRON_VERSION_STRING} SOVERSION ${GADGETRON_SOVERSION})
 
 target_link_libraries(gadgetron_compression
     gadgetron_gadgetbase
@@ -38,7 +49,5 @@ install(FILES
 
 install(TARGETS gadgetron_compression DESTINATION lib COMPONENT main)
 install(FILES
-        config/default_compression.xml
-        config/Generic_Cartesian_Grappa_SNR_Compression.xml
-        config/ismrmrd_dump_compressed.xml
+         ${config_files} 
         DESTINATION ${GADGETRON_INSTALL_CONFIG_PATH} COMPONENT main)

--- a/gadgets/compression/GadgetIsmrmrdCompressedReadWrite.h
+++ b/gadgets/compression/GadgetIsmrmrdCompressedReadWrite.h
@@ -131,9 +131,9 @@ namespace Gadgetron{
                 return 0;
             }
             
-            size_t nx = MAX(field->nx, 1u);
-            size_t ny = MAX(field->ny, 1u);
-            size_t nz = MAX(field->nz, 1u);
+            size_t nx = std::max(field->nx, 1u);
+            size_t ny = std::max(field->ny, 1u);
+            size_t nz = std::max(field->nz, 1u);
 
             if (nx*ny*nz != (m1->getObjectPtr()->number_of_samples*2*m1->getObjectPtr()->active_channels)) {
                 GERROR("Size of decompressed stream does not match the acquisition header\n");

--- a/gadgets/compression/config/Generic_Cartesian_Grappa_EPI_AVE_Compression.xml
+++ b/gadgets/compression/config/Generic_Cartesian_Grappa_EPI_AVE_Compression.xml
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gadgetronStreamConfiguration xsi:schemaLocation="http://gadgetron.sf.net/gadgetron gadgetron.xsd"
+        xmlns="http://gadgetron.sf.net/gadgetron"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <!--
+        Gadgetron generic recon chain for 2D cartesian EPI sampling
+
+        EPI imaging
+        Triggered by average
+        Recon N is repetition and S is set
+
+        Author: Hui Xue
+        Magnetic Resonance Technology Program, National Heart, Lung and Blood Institute, National Institutes of Health
+        10 Center Drive, Bethesda, MD 20814, USA
+        Email: hui.xue@nih.gov
+    -->
+
+    <!-- reader -->
+    <reader><slot>1008</slot><dll>gadgetron_mricore</dll><classname>GadgetIsmrmrdAcquisitionMessageReader</classname></reader>
+    <reader><slot>1024</slot><dll>gadgetron_compression</dll><classname>GadgetIsmrmrdCompressedAcquisitionMessageReader</classname></reader>
+
+    <!-- writer -->
+    <writer><slot>1022</slot><dll>gadgetron_mricore</dll><classname>MRIImageWriter</classname></writer>
+
+    <!-- Noise prewhitening -->
+    <gadget><name>NoiseAdjust</name><dll>gadgetron_mricore</dll><classname>NoiseAdjustGadget</classname></gadget>
+
+    <!-- EPI correction -->
+    <gadget>
+        <name>ReconX</name>
+        <dll>gadgetron_epi</dll>
+        <classname>EPIReconXGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>EPICorr</name>
+        <dll>gadgetron_epi</dll>
+        <classname>EPICorrGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>FFTX</name>
+        <dll>gadgetron_epi</dll>
+        <classname>FFTXGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>OneEncodingSpace</name>
+        <dll>gadgetron_epi</dll>
+        <classname>OneEncodingGadget</classname>
+    </gadget>
+
+    <!-- Data accumulation and trigger gadget -->
+    <gadget>
+        <name>AccTrig</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>AcquisitionAccumulateTriggerGadget</classname>
+        <property><name>trigger_dimension</name><value>average</value></property>
+        <property><name>sorting_dimension</name><value>repetition</value></property>
+    </gadget>
+
+    <gadget>
+        <name>BucketToBuffer</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>BucketToBufferGadget</classname>
+        <property><name>N_dimension</name><value>average</value></property>
+        <property><name>S_dimension</name><value>repetition</value></property>
+        <property><name>split_slices</name><value>false</value></property>
+        <property><name>ignore_segment</name><value>true</value></property>
+    </gadget>
+
+    <!-- Prep ref -->
+    <gadget>
+        <name>PrepRef</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconCartesianReferencePrepGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <!-- averaging across repetition -->
+        <property><name>average_all_ref_N</name><value>true</value></property>
+        <!-- every set has its own kernels -->
+        <property><name>average_all_ref_S</name><value>true</value></property>
+        <!-- whether always to prepare ref if no acceleration is used -->
+        <property><name>prepare_ref_always</name><value>false</value></property>
+    </gadget>
+
+    <!-- Coil compression -->
+    <gadget>
+        <name>CoilCompression</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconEigenChannelGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <property><name>average_all_ref_N</name><value>true</value></property>
+        <property><name>average_all_ref_S</name><value>true</value></property>
+
+        <!-- Up stream coil compression -->
+        <property><name>upstream_coil_compression</name><value>true</value></property>
+        <property><name>upstream_coil_compression_thres</name><value>-1</value></property>
+        <property><name>upstream_coil_compression_num_modesKept</name><value>0</value></property>
+    </gadget>
+
+    <!-- Recon -->
+    <gadget>
+        <name>Recon</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconCartesianGrappaGadget</classname>
+
+        <!-- image series -->
+        <property><name>image_series</name><value>0</value></property>
+
+        <!-- Coil map estimation, Inati or Inati_Iter -->
+        <property><name>coil_map_algorithm</name><value>Inati</value></property>
+
+        <!-- Down stream coil compression -->
+        <property><name>downstream_coil_compression</name><value>true</value></property>
+        <property><name>downstream_coil_compression_thres</name><value>0.002</value></property>
+        <property><name>downstream_coil_compression_num_modesKept</name><value>0</value></property>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <!-- whether to send out gfactor -->
+        <property><name>send_out_gfactor</name><value>false</value></property>
+    </gadget>
+
+    <!-- Partial fourier handling -->
+    <gadget>
+        <name>PartialFourierHandling</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconPartialFourierHandlingFilterGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+
+        <!-- if incoming images have this meta field, it will not be processed -->
+        <property><name>skip_processing_meta_field</name><value>Skip_processing_after_recon</value></property>
+
+        <!-- Parfial fourier handling filter parameters -->
+        <property><name>partial_fourier_filter_RO_width</name><value>0.15</value></property>
+        <property><name>partial_fourier_filter_E1_width</name><value>0.15</value></property>
+        <property><name>partial_fourier_filter_E2_width</name><value>0.15</value></property>
+        <property><name>partial_fourier_filter_densityComp</name><value>false</value></property>
+    </gadget>
+
+    <!-- Kspace filtering -->
+    <gadget>
+        <name>KSpaceFilter</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconKSpaceFilteringGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+
+        <!-- if incoming images have this meta field, it will not be processed -->
+        <property><name>skip_processing_meta_field</name><value>Skip_processing_after_recon</value></property>
+
+        <!-- parameters for kspace filtering -->
+        <property><name>filterRO</name><value>Gaussian</value></property>
+        <property><name>filterRO_sigma</name><value>1.0</value></property>
+        <property><name>filterRO_width</name><value>0.15</value></property>
+
+        <property><name>filterE1</name><value>Gaussian</value></property>
+        <property><name>filterE1_sigma</name><value>1.0</value></property>
+        <property><name>filterE1_width</name><value>0.15</value></property>
+
+        <property><name>filterE2</name><value>Gaussian</value></property>
+        <property><name>filterE2_sigma</name><value>1.0</value></property>
+        <property><name>filterE2_width</name><value>0.15</value></property>
+    </gadget>
+
+    <!-- FOV Adjustment -->
+    <gadget>
+        <name>FOVAdjustment</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconFieldOfViewAdjustmentGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+    </gadget>
+
+    <!-- Image Array Scaling -->
+    <gadget>
+        <name>Scaling</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconImageArrayScalingGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+
+        <property><name>min_intensity_value</name><value>64</value></property>
+        <property><name>max_intensity_value</name><value>4095</value></property>
+        <property><name>scalingFactor</name><value>4.0</value></property>
+        <property><name>use_constant_scalingFactor</name><value>false</value></property>
+        <property><name>auto_scaling_only_once</name><value>true</value></property>
+        <property><name>scalingFactor_dedicated</name><value>100.0</value></property>
+    </gadget>
+
+    <!-- ImageArray to images -->
+    <gadget>
+        <name>ImageArraySplit</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ImageArraySplitGadget</classname>
+    </gadget>
+
+    <!-- after recon processing -->
+    <gadget>
+        <name>ComplexToFloatAttrib</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ComplexToFloatGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>FloatToShortAttrib</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>FloatToUShortGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>ImageFinish</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ImageFinishGadget</classname>
+    </gadget>
+
+</gadgetronStreamConfiguration>

--- a/gadgets/compression/config/Generic_Cartesian_Grappa_EPI_Compression.xml
+++ b/gadgets/compression/config/Generic_Cartesian_Grappa_EPI_Compression.xml
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gadgetronStreamConfiguration xsi:schemaLocation="http://gadgetron.sf.net/gadgetron gadgetron.xsd"
+        xmlns="http://gadgetron.sf.net/gadgetron"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <!--
+        Gadgetron generic recon chain for 2D cartesian EPI sampling
+
+        EPI imaging
+        Triggered by repetition
+        Recon N is repetition and S is set
+
+        Author: Hui Xue
+        Magnetic Resonance Technology Program, National Heart, Lung and Blood Institute, National Institutes of Health
+        10 Center Drive, Bethesda, MD 20814, USA
+        Email: hui.xue@nih.gov
+    -->
+
+    <!-- reader -->
+    <reader><slot>1008</slot><dll>gadgetron_mricore</dll><classname>GadgetIsmrmrdAcquisitionMessageReader</classname></reader>
+    <reader><slot>1024</slot><dll>gadgetron_compression</dll><classname>GadgetIsmrmrdCompressedAcquisitionMessageReader</classname></reader>
+
+    <!-- writer -->
+    <writer><slot>1022</slot><dll>gadgetron_mricore</dll><classname>MRIImageWriter</classname></writer>
+
+    <!-- Noise prewhitening -->
+    <gadget><name>NoiseAdjust</name><dll>gadgetron_mricore</dll><classname>NoiseAdjustGadget</classname></gadget>
+
+    <!-- EPI correction -->
+    <gadget>
+        <name>ReconX</name>
+        <dll>gadgetron_epi</dll>
+        <classname>EPIReconXGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>EPICorr</name>
+        <dll>gadgetron_epi</dll>
+        <classname>EPICorrGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>FFTX</name>
+        <dll>gadgetron_epi</dll>
+        <classname>FFTXGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>OneEncodingSpace</name>
+        <dll>gadgetron_epi</dll>
+        <classname>OneEncodingGadget</classname>
+    </gadget>
+
+    <!-- Data accumulation and trigger gadget -->
+    <gadget>
+        <name>AccTrig</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>AcquisitionAccumulateTriggerGadget</classname>
+        <property><name>trigger_dimension</name><value>repetition</value></property>
+        <property><name>sorting_dimension</name><value>average</value></property>
+    </gadget>
+
+    <gadget>
+        <name>BucketToBuffer</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>BucketToBufferGadget</classname>
+        <property><name>N_dimension</name><value>repetition</value></property>
+        <property><name>S_dimension</name><value>average</value></property>
+        <property><name>split_slices</name><value>false</value></property>
+        <property><name>ignore_segment</name><value>true</value></property>
+    </gadget>
+
+    <!-- Prep ref -->
+    <gadget>
+        <name>PrepRef</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconCartesianReferencePrepGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <!-- averaging across repetition -->
+        <property><name>average_all_ref_N</name><value>true</value></property>
+        <!-- every set has its own kernels -->
+        <property><name>average_all_ref_S</name><value>true</value></property>
+        <!-- whether always to prepare ref if no acceleration is used -->
+        <property><name>prepare_ref_always</name><value>false</value></property>
+    </gadget>
+
+    <!-- Coil compression -->
+    <gadget>
+        <name>CoilCompression</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconEigenChannelGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <property><name>average_all_ref_N</name><value>true</value></property>
+        <property><name>average_all_ref_S</name><value>true</value></property>
+
+        <!-- Up stream coil compression -->
+        <property><name>upstream_coil_compression</name><value>true</value></property>
+        <property><name>upstream_coil_compression_thres</name><value>-1</value></property>
+        <property><name>upstream_coil_compression_num_modesKept</name><value>0</value></property>
+    </gadget>
+
+    <!-- Recon -->
+    <gadget>
+        <name>Recon</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconCartesianGrappaGadget</classname>
+
+        <!-- image series -->
+        <property><name>image_series</name><value>0</value></property>
+
+        <!-- Coil map estimation, Inati or Inati_Iter -->
+        <property><name>coil_map_algorithm</name><value>Inati</value></property>
+
+        <!-- Down stream coil compression -->
+        <property><name>downstream_coil_compression</name><value>true</value></property>
+        <property><name>downstream_coil_compression_thres</name><value>0.002</value></property>
+        <property><name>downstream_coil_compression_num_modesKept</name><value>0</value></property>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <!-- whether to send out gfactor -->
+        <property><name>send_out_gfactor</name><value>false</value></property>
+    </gadget>
+
+    <!-- Partial fourier handling -->
+    <gadget>
+        <name>PartialFourierHandling</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconPartialFourierHandlingFilterGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+
+        <!-- if incoming images have this meta field, it will not be processed -->
+        <property><name>skip_processing_meta_field</name><value>Skip_processing_after_recon</value></property>
+
+        <!-- Parfial fourier handling filter parameters -->
+        <property><name>partial_fourier_filter_RO_width</name><value>0.15</value></property>
+        <property><name>partial_fourier_filter_E1_width</name><value>0.15</value></property>
+        <property><name>partial_fourier_filter_E2_width</name><value>0.15</value></property>
+        <property><name>partial_fourier_filter_densityComp</name><value>false</value></property>
+    </gadget>
+
+    <!-- Kspace filtering -->
+    <gadget>
+        <name>KSpaceFilter</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconKSpaceFilteringGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+
+        <!-- if incoming images have this meta field, it will not be processed -->
+        <property><name>skip_processing_meta_field</name><value>Skip_processing_after_recon</value></property>
+
+        <!-- parameters for kspace filtering -->
+        <property><name>filterRO</name><value>Gaussian</value></property>
+        <property><name>filterRO_sigma</name><value>1.0</value></property>
+        <property><name>filterRO_width</name><value>0.15</value></property>
+
+        <property><name>filterE1</name><value>Gaussian</value></property>
+        <property><name>filterE1_sigma</name><value>1.0</value></property>
+        <property><name>filterE1_width</name><value>0.15</value></property>
+
+        <property><name>filterE2</name><value>Gaussian</value></property>
+        <property><name>filterE2_sigma</name><value>1.0</value></property>
+        <property><name>filterE2_width</name><value>0.15</value></property>
+    </gadget>
+
+    <!-- FOV Adjustment -->
+    <gadget>
+        <name>FOVAdjustment</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconFieldOfViewAdjustmentGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+    </gadget>
+
+    <!-- Image Array Scaling -->
+    <gadget>
+        <name>Scaling</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconImageArrayScalingGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+
+        <property><name>min_intensity_value</name><value>64</value></property>
+        <property><name>max_intensity_value</name><value>4095</value></property>
+        <property><name>scalingFactor</name><value>4.0</value></property>
+        <property><name>use_constant_scalingFactor</name><value>false</value></property>
+        <property><name>auto_scaling_only_once</name><value>true</value></property>
+        <property><name>scalingFactor_dedicated</name><value>100.0</value></property>
+    </gadget>
+
+    <!-- ImageArray to images -->
+    <gadget>
+        <name>ImageArraySplit</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ImageArraySplitGadget</classname>
+    </gadget>
+
+    <!-- after recon processing -->
+    <gadget>
+        <name>ComplexToFloatAttrib</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ComplexToFloatGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>FloatToShortAttrib</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>FloatToUShortGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>ImageFinish</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ImageFinishGadget</classname>
+    </gadget>
+
+</gadgetronStreamConfiguration>

--- a/gadgets/compression/config/Generic_Cartesian_Grappa_RealTimeCine_Compression.xml
+++ b/gadgets/compression/config/Generic_Cartesian_Grappa_RealTimeCine_Compression.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gadgetronStreamConfiguration xsi:schemaLocation="http://gadgetron.sf.net/gadgetron gadgetron.xsd"
+        xmlns="http://gadgetron.sf.net/gadgetron"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <!--
+        Gadgetron generic recon chain for 2D and 3D cartesian sampling
+
+        RealTimeCine imaging
+        Triggered by slice
+        Recon N is phase and S is set
+
+        Author: Hui Xue
+        Magnetic Resonance Technology Program, National Heart, Lung and Blood Institute, National Institutes of Health
+        10 Center Drive, Bethesda, MD 20814, USA
+        Email: hui.xue@nih.gov
+    -->
+
+    <!-- reader -->
+    <reader><slot>1008</slot><dll>gadgetron_mricore</dll><classname>GadgetIsmrmrdAcquisitionMessageReader</classname></reader>
+    <reader><slot>1024</slot><dll>gadgetron_compression</dll><classname>GadgetIsmrmrdCompressedAcquisitionMessageReader</classname></reader>
+
+    <!-- writer -->
+    <writer><slot>1022</slot><dll>gadgetron_mricore</dll><classname>MRIImageWriter</classname></writer>
+
+    <!-- Noise prewhitening -->
+    <gadget><name>NoiseAdjust</name><dll>gadgetron_mricore</dll><classname>NoiseAdjustGadget</classname></gadget>
+
+    <!-- RO asymmetric echo handling -->
+    <gadget><name>AsymmetricEcho</name><dll>gadgetron_mricore</dll><classname>AsymmetricEchoAdjustROGadget</classname></gadget>
+
+    <!-- RO oversampling removal -->
+    <gadget><name>RemoveROOversampling</name><dll>gadgetron_mricore</dll><classname>RemoveROOversamplingGadget</classname></gadget>
+
+    <!-- Data accumulation and trigger gadget -->
+    <gadget>
+        <name>AccTrig</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>AcquisitionAccumulateTriggerGadget</classname>
+        <property><name>trigger_dimension</name><value>slice</value></property>
+        <property><name>sorting_dimension</name><value></value></property>
+    </gadget>
+
+    <gadget>
+        <name>BucketToBuffer</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>BucketToBufferGadget</classname>
+        <property><name>N_dimension</name><value>phase</value></property>
+        <property><name>S_dimension</name><value>set</value></property>
+        <property><name>split_slices</name><value>true</value></property>
+        <property><name>ignore_segment</name><value>true</value></property>
+    </gadget>
+
+    <!-- Prep ref -->
+    <gadget>
+        <name>PrepRef</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconCartesianReferencePrepGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <!-- averaging across repetition -->
+        <property><name>average_all_ref_N</name><value>true</value></property>
+        <!-- every set has its own kernels -->
+        <property><name>average_all_ref_S</name><value>false</value></property>
+        <!-- whether always to prepare ref if no acceleration is used -->
+        <property><name>prepare_ref_always</name><value>true</value></property>
+    </gadget>
+
+    <!-- Coil compression -->
+    <gadget>
+        <name>CoilCompression</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconEigenChannelGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <property><name>average_all_ref_N</name><value>true</value></property>
+        <property><name>average_all_ref_S</name><value>true</value></property>
+
+        <!-- Up stream coil compression -->
+        <property><name>upstream_coil_compression</name><value>true</value></property>
+        <property><name>upstream_coil_compression_thres</name><value>-1</value></property>
+        <property><name>upstream_coil_compression_num_modesKept</name><value>0</value></property>
+    </gadget>
+
+    <!-- Recon -->
+    <gadget>
+        <name>Recon</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconCartesianGrappaGadget</classname>
+
+        <!-- image series -->
+        <property><name>image_series</name><value>0</value></property>
+
+        <!-- Coil map estimation, Inati or Inati_Iter -->
+        <property><name>coil_map_algorithm</name><value>Inati</value></property>
+
+        <!-- Down stream coil compression -->
+        <property><name>downstream_coil_compression</name><value>true</value></property>
+        <property><name>downstream_coil_compression_thres</name><value>0.002</value></property>
+        <property><name>downstream_coil_compression_num_modesKept</name><value>0</value></property>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <!-- whether to send out gfactor -->
+        <property><name>send_out_gfactor</name><value>true</value></property>
+    </gadget>
+
+    <!-- Partial fourier handling -->
+    <gadget>
+        <name>PartialFourierHandling</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconPartialFourierHandlingPOCSGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+
+        <!-- if incoming images have this meta field, it will not be processed -->
+        <property><name>skip_processing_meta_field</name><value>Skip_processing_after_recon</value></property>
+
+        <!-- Parfial fourier POCS parameters -->
+        <property><name>partial_fourier_POCS_iters</name><value>6</value></property>
+        <property><name>partial_fourier_POCS_thres</name><value>0.01</value></property>
+        <property><name>partial_fourier_POCS_transitBand</name><value>24</value></property>
+        <property><name>partial_fourier_POCS_transitBand_E2</name><value>16</value></property>
+    </gadget>
+
+    <!-- Kspace filtering -->
+    <gadget>
+        <name>KSpaceFilter</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconKSpaceFilteringGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+
+        <!-- if incoming images have this meta field, it will not be processed -->
+        <property><name>skip_processing_meta_field</name><value>Skip_processing_after_recon</value></property>
+
+        <!-- parameters for kspace filtering -->
+        <property><name>filterRO</name><value>Gaussian</value></property>
+        <property><name>filterRO_sigma</name><value>1.0</value></property>
+        <property><name>filterRO_width</name><value>0.15</value></property>
+
+        <property><name>filterE1</name><value>Gaussian</value></property>
+        <property><name>filterE1_sigma</name><value>1.0</value></property>
+        <property><name>filterE1_width</name><value>0.15</value></property>
+
+        <property><name>filterE2</name><value>Gaussian</value></property>
+        <property><name>filterE2_sigma</name><value>1.0</value></property>
+        <property><name>filterE2_width</name><value>0.15</value></property>
+    </gadget>
+
+        <!-- FOV Adjustment -->
+    <gadget>
+        <name>FOVAdjustment</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconFieldOfViewAdjustmentGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+    </gadget>
+
+        <!-- Image Array Scaling -->
+    <gadget>
+        <name>Scaling</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconImageArrayScalingGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+
+        <property><name>min_intensity_value</name><value>64</value></property>
+        <property><name>max_intensity_value</name><value>4095</value></property>
+        <property><name>scalingFactor</name><value>10.0</value></property>
+        <property><name>use_constant_scalingFactor</name><value>true</value></property>
+        <property><name>auto_scaling_only_once</name><value>true</value></property>
+        <property><name>scalingFactor_dedicated</name><value>100.0</value></property>
+    </gadget>
+
+    <!-- ImageArray to images -->
+    <gadget>
+        <name>ImageArraySplit</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ImageArraySplitGadget</classname>
+    </gadget>
+
+    <!-- after recon processing -->
+    <gadget>
+        <name>ComplexToFloatAttrib</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ComplexToFloatGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>FloatToShortAttrib</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>FloatToUShortGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>ImageFinish</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ImageFinishGadget</classname>
+    </gadget>
+
+</gadgetronStreamConfiguration>

--- a/gadgets/compression/config/Generic_Cartesian_NonLinear_Spirit_RealTimeCine_Compression_Cloud.xml
+++ b/gadgets/compression/config/Generic_Cartesian_NonLinear_Spirit_RealTimeCine_Compression_Cloud.xml
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gadgetronStreamConfiguration xsi:schemaLocation="http://gadgetron.sf.net/gadgetron gadgetron.xsd"
+        xmlns="http://gadgetron.sf.net/gadgetron"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <!--
+        Gadgetron generic recon chain for 2DT cartesian sampling with the Nonlinear SPIRIT reconstruction
+
+        RealTime Cine imaging on the cloud, using the distribution gadget
+        Triggered by slice
+        Recon N is phase and S is set
+
+        Author: Hui Xue
+        Magnetic Resonance Technology Program, National Heart, Lung and Blood Institute, National Institutes of Health
+        10 Center Drive, Bethesda, MD 20814, USA
+        Email: hui.xue@nih.gov
+    -->
+
+    <!-- reader -->
+    <reader><slot>1008</slot><dll>gadgetron_mricore</dll><classname>GadgetIsmrmrdAcquisitionMessageReader</classname></reader>
+    <reader><slot>1022</slot><dll>gadgetron_mricore</dll><classname>MRIImageReader</classname></reader>
+    <reader><slot>1024</slot><dll>gadgetron_compression</dll><classname>GadgetIsmrmrdCompressedAcquisitionMessageReader</classname></reader>
+
+    <!-- writer -->
+    <writer><slot>1022</slot><dll>gadgetron_mricore</dll><classname>MRIImageWriter</classname></writer>
+    <writer><slot>1008</slot><dll>gadgetron_mricore</dll><classname>GadgetIsmrmrdAcquisitionMessageWriter</classname></writer>
+
+    <!-- Noise prewhitening -->
+    <gadget><name>NoiseAdjust</name><dll>gadgetron_mricore</dll><classname>NoiseAdjustGadget</classname></gadget>
+
+    <!-- RO asymmetric echo handling -->
+    <gadget><name>AsymmetricEcho</name><dll>gadgetron_mricore</dll><classname>AsymmetricEchoAdjustROGadget</classname></gadget>
+
+    <!-- RO oversampling removal -->
+    <gadget><name>RemoveROOversampling</name><dll>gadgetron_mricore</dll><classname>RemoveROOversamplingGadget</classname></gadget>
+
+    <!-- Distribute slice over nodes -->
+    <gadget>
+      <name>Distribute</name>
+      <dll>gadgetron_distributed</dll>
+      <classname>IsmrmrdAcquisitionDistributeGadget</classname>
+      <property><name>parallel_dimension</name><value>slice</value></property>
+      <property><name>use_this_node_for_compute</name><value>false</value></property>
+    </gadget>
+
+    <!-- Data accumulation and trigger gadget -->
+    <gadget>
+        <name>AccTrig</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>AcquisitionAccumulateTriggerGadget</classname>
+        <property><name>trigger_dimension</name><value>slice</value></property>
+        <property><name>sorting_dimension</name><value></value></property>
+    </gadget>
+
+    <gadget>
+        <name>BucketToBuffer</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>BucketToBufferGadget</classname>
+        <property><name>N_dimension</name><value>phase</value></property>
+        <property><name>S_dimension</name><value>set</value></property>
+        <property><name>split_slices</name><value>false</value></property>
+        <property><name>ignore_segment</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+    </gadget>
+
+    <!-- Prep ref -->
+    <gadget>
+        <name>PrepRef</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconCartesianReferencePrepGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <!-- averaging across repetition -->
+        <property><name>average_all_ref_N</name><value>true</value></property>
+        <!-- every set has its own kernels -->
+        <property><name>average_all_ref_S</name><value>true</value></property>
+        <!-- whether always to prepare ref if no acceleration is used -->
+        <property><name>prepare_ref_always</name><value>true</value></property>
+    </gadget>
+
+    <!-- Coil compression -->
+    <gadget>
+        <name>CoilCompression</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconEigenChannelGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>false</value></property>
+
+        <property><name>average_all_ref_N</name><value>true</value></property>
+        <property><name>average_all_ref_S</name><value>true</value></property>
+
+        <!-- Up stream coil compression -->
+        <property><name>upstream_coil_compression</name><value>true</value></property>
+        <property><name>upstream_coil_compression_thres</name><value>0.001</value></property>
+        <property><name>upstream_coil_compression_num_modesKept</name><value>0</value></property>
+    </gadget>
+
+    <!-- Recon -->
+    <gadget>
+        <name>Recon</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconCartesianNonLinearSpirit2DTGadget</classname>
+
+        <!-- image series -->
+        <property><name>image_series</name><value>0</value></property>
+
+        <!-- Coil map estimation, Inati or Inati_Iter -->
+        <property><name>coil_map_algorithm</name><value>Inati</value></property>
+
+        <!-- parameters for SPIRIT recon -->
+        <property><name>spirit_parallel_imaging_lamda</name><value>1.0</value></property>
+        <property><name>spirit_data_fidelity_lamda</name><value>1.0</value></property>
+        <property><name>spirit_reg_name</name><value>db2</value></property>
+        <property><name>spirit_reg_level</name><value>1</value></property>
+        <property><name>spirit_reg_keep_approx_coeff</name><value>true</value></property>
+        <property><name>spirit_reg_keep_redundant_dimension_coeff</name><value>false</value></property>
+        <property><name>spirit_reg_proximity_across_cha</name><value>false</value></property>
+        <property><name>spirit_reg_use_coil_sen_map</name><value>false</value></property>
+        <property><name>spirit_reg_RO_weighting_ratio</name><value>1.0</value></property>
+        <property><name>spirit_reg_E1_weighting_ratio</name><value>1.0</value></property>
+        <property><name>spirit_print_iter</name><value>true</value></property>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+    </gadget>
+
+    <!-- Partial fourier handling -->
+    <gadget>
+        <name>PartialFourierHandling</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconPartialFourierHandlingPOCSGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <!-- if incoming images have this meta field, it will not be processed -->
+        <property><name>skip_processing_meta_field</name><value>Skip_processing_after_recon</value></property>
+
+        <!-- Parfial fourier POCS parameters -->
+        <property><name>partial_fourier_POCS_iters</name><value>6</value></property>
+        <property><name>partial_fourier_POCS_thres</name><value>0.01</value></property>
+        <property><name>partial_fourier_POCS_transitBand</name><value>24</value></property>
+        <property><name>partial_fourier_POCS_transitBand_E2</name><value>16</value></property>
+    </gadget>
+
+    <!-- Kspace filtering -->
+    <gadget>
+        <name>KSpaceFilter</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconKSpaceFilteringGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+
+        <!-- if incoming images have this meta field, it will not be processed -->
+        <property><name>skip_processing_meta_field</name><value>Skip_processing_after_recon</value></property>
+
+        <!-- parameters for kspace filtering -->
+        <property><name>filterRO</name><value>Gaussian</value></property>
+        <property><name>filterRO_sigma</name><value>1.0</value></property>
+        <property><name>filterRO_width</name><value>0.15</value></property>
+
+        <property><name>filterE1</name><value>Gaussian</value></property>
+        <property><name>filterE1_sigma</name><value>1.0</value></property>
+        <property><name>filterE1_width</name><value>0.15</value></property>
+
+        <property><name>filterE2</name><value>Gaussian</value></property>
+        <property><name>filterE2_sigma</name><value>1.0</value></property>
+        <property><name>filterE2_width</name><value>0.15</value></property>
+    </gadget>
+
+    <!-- FOV Adjustment -->
+    <gadget>
+        <name>FOVAdjustment</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconFieldOfViewAdjustmentGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+    </gadget>
+
+    <!-- Image Array Scaling -->
+    <gadget>
+        <name>Scaling</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconImageArrayScalingGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+
+        <property><name>min_intensity_value</name><value>64</value></property>
+        <property><name>max_intensity_value</name><value>4095</value></property>
+        <property><name>scalingFactor</name><value>10.0</value></property>
+        <property><name>use_constant_scalingFactor</name><value>true</value></property>
+        <property><name>auto_scaling_only_once</name><value>true</value></property>
+        <property><name>scalingFactor_dedicated</name><value>100.0</value></property>
+    </gadget>
+
+    <!-- ImageArray to images -->
+    <gadget>
+        <name>ImageArraySplit</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ImageArraySplitGadget</classname>
+    </gadget>
+
+    <!-- Collect images from nodes -->
+    <gadget>
+        <name>Collect</name>
+        <dll>gadgetron_distributed</dll>
+        <classname>CollectGadget</classname>
+    </gadget>
+
+    <!-- Physio interpolation -->
+    <gadget>
+        <name>PhysioInterpolation</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>PhysioInterpolationGadget</classname>
+        <property><name>phases</name><value>30</value></property>
+        <!-- 0=seperate series for each complete RR -->
+        <!-- 1=First complete RR interval only -->
+        <property><name>mode</name><value>0</value></property>
+        <property><name>first_beat_on_trigger</name><value>true</value></property>
+        <!-- "Spline" or "BSpline" -->
+        <property><name>interp_method</name><value>BSpline</value></property>
+    </gadget>
+
+    <!-- after recon processing -->
+    <gadget>
+        <name>ComplexToFloatAttrib</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ComplexToFloatGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>FloatToShortAttrib</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>FloatToUShortGadget</classname>
+
+        <property><name>max_intensity</name><value>32767</value></property>
+        <property><name>min_intensity</name><value>0</value></property>
+        <property><name>intensity_offset</name><value>0</value></property>
+    </gadget>
+
+    <gadget>
+        <name>ImageFinish</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ImageFinishGadget</classname>
+    </gadget>
+
+</gadgetronStreamConfiguration>


### PR DESCRIPTION
fix one place (MAX) for windows compilation
add a few more xml to use compression

test on some realtime cine data
e.g.

R=4, 192*111 acquired matrix

compressed | origin
difference

![image](https://cloud.githubusercontent.com/assets/7012710/16046703/694f2bb4-321b-11e6-8362-38f47d2cf183.png)

Gfactor map (Left: compressed; Right: original)

![image](https://cloud.githubusercontent.com/assets/7012710/16046750/838925c0-321b-11e6-8af2-83119d92302d.png)

![image](https://cloud.githubusercontent.com/assets/7012710/16046753/881403f8-321b-11e6-9f82-55905b4cb6dc.png)

Using -P 12
